### PR TITLE
React PropTypes update

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "react-scripts": "0.8.4"
   },
   "dependencies": {
-    "react": "^15.4.1",
-    "react-dom": "^15.4.1"
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/Countdown.js
+++ b/src/Countdown.js
@@ -1,4 +1,12 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types'
+
+/**
+ * Note : 
+ * If you're using react v 15.4 or less
+ * You can directly import PropTypes from react instead. 
+ * Refer to this : https://reactjs.org/warnings/dont-call-proptypes.html
+ */
 
 class Countdown extends Component {
   constructor(props) {


### PR DESCRIPTION
I was integrating your wonderful countdown component to my react app was only able to crash my application.  After debugging found that you are using deprecated  way of importing PropTypes. 

Refer to this:
https://reactjs.org/warnings/dont-call-proptypes.html

I've updated application to use 'prop-types' package instead of direct import from react.